### PR TITLE
README updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ debootstrap: $(disk) $(mnt)
 	sudo mount -o loop $(disk) $(mnt)
 	sudo debootstrap --components=main,universe \
 		--include="build-essential vim kmod net-tools apache2 apache2-utils haveged cgroupfs-mount iptables libltdl7 redis-server redis-tools nginx sysbench php memcached" \
-		--arch=amd64 cosmic $(mnt) http://archive.ubuntu.com/ubuntu
+		--arch=amd64 cosmic $(mnt) http://old-releases.ubuntu.com/ubuntu
 	sudo umount --recursive $(mnt)
 	make install-docker install-mark sync-scripts
 

--- a/README.md
+++ b/README.md
@@ -30,11 +30,12 @@ generate the final configuration.
 
 ```
 source constants.sh
+make $mnt; make $disk # set-up mnt folder and qemu disk
 make setup-qemu # patch the qemu to enable PC tracing
 make setup-linux # clone the linux source
 make build-db # parse the linux source to extract the relationships between the configuration options and code
-make build-base # build the vanilla kernel as the baseline
 make debootstrap # create a rootfs for the VM
+make build-base # build the vanilla kernel as the baseline
 ./trace-kernel.sh [program in the guest] # trace the workload and generate the configuration 
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ generate the final configuration.
 ## How can I use Cozart?
 
 ```
-source constants.sh
+source constant.sh
 make $mnt; make $disk # set-up mnt folder and qemu disk
 make setup-qemu # patch the qemu to enable PC tracing
 make setup-linux # clone the linux source


### PR DESCRIPTION
`make debootstrap` and `make build-base` were out of order: the latter calls `make install-kernel-modules` which relies on the qemu disk being setup (through `mkfs.ext4 $(disk)` in `make debootstrap`)

also, there was a small typo regarding the constant.sh file