### PR TITLE
fix(#24): modify repo of linux-cosmic and add commands to shell scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ build-db:
 		awk -f postproc-fndb.awk | sed 's/^\.\///' >filename.db
 
 setup-linux:
-	git clone --depth=1 git://kernel.ubuntu.com/ubuntu/ubuntu-cosmic.git $(linux)
+	git clone --depth=1 https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/cosmic $(linux)
 	cd $(linux) && \
 		git apply -v ../patches/watchdog.patch
 	make remove-makefile-escaped-newlines

--- a/benchmark-scripts/general-helper.sh
+++ b/benchmark-scripts/general-helper.sh
@@ -13,6 +13,7 @@ mount_fs() {
 }
 
 enable_network() {
+    depmod
     modprobe e1000;
     hostname qemu
     echo "127.0.0.1  localhost.localdomain localhost" > /etc/hosts

--- a/install_mysql_host.sh
+++ b/install_mysql_host.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 source constant.sh
 #Would you like to setup VALIDATE PASSWORD plugin? NO
 #New password: root


### PR DESCRIPTION
The original Linux cosmic repo `git://kernel.ubuntu.com/ubuntu/ubuntu-cosmic.git` is no longer available. 
This submission modifies it to a new source [https://git.launchpad.net/ ~Ubuntu kernel/ubuntu/+source/Linux/+git/Cosmic](https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/cosmic)

(cherry picked from commit bfb0ef296986a5b9adc3784ba85b361ef85c3763)
this commit fixes #24